### PR TITLE
Refactor: Hide and reset gender filter on category selection

### DIFF
--- a/js/products.js
+++ b/js/products.js
@@ -121,6 +121,18 @@ document.addEventListener('DOMContentLoaded', async function() {
                 this.classList.add('active');
                 currentActiveCategoryButton = this;
                 currentCategory = this.dataset.category; // Update currentCategory
+                // Show/hide gender filter
+                if (this.dataset.category === 'all') {
+                    genderFilterContainer.style.display = 'flex';
+                } else {
+                    genderFilterContainer.style.display = 'none';
+                    // Reset gender filter to 'all'
+                    const genderSelect = document.getElementById('gender-select');
+                    if (genderSelect) {
+                        genderSelect.value = 'all';
+                    }
+                    currentGender = 'all';
+                }
                 await fetchAndDisplayProducts(currentCategory, currentGender); // Modified call
             });
             categoryFilterContainer.appendChild(allButton);
@@ -147,6 +159,18 @@ document.addEventListener('DOMContentLoaded', async function() {
                         this.classList.add('active');
                         currentActiveCategoryButton = this;
                         currentCategory = this.dataset.category; // Update currentCategory
+                        // Show/hide gender filter
+                        if (this.dataset.category === 'all') {
+                            genderFilterContainer.style.display = 'flex';
+                        } else {
+                            genderFilterContainer.style.display = 'none';
+                            // Reset gender filter to 'all'
+                            const genderSelect = document.getElementById('gender-select');
+                            if (genderSelect) {
+                                genderSelect.value = 'all';
+                            }
+                            currentGender = 'all';
+                        }
                         await fetchAndDisplayProducts(currentCategory, currentGender); // Modified call
                     });
                     categoryFilterContainer.appendChild(button);


### PR DESCRIPTION
This commit implements changes to the product filtering functionality on the products page (`products.html` and `js/products.js`).

When you select a specific product category:
1. The gender selection dropdown is now hidden from view.
2. Any previously selected gender is neutralized, and the filter resets to 'All Genders'. This ensures that selecting a category always shows all products within that category, regardless of any prior gender filter state.

When you select the 'All' category:
1. The gender selection dropdown is made visible again, allowing you to filter by gender across all categories.

This change improves the user experience by simplifying the filtering logic when categories are actively being selected.