### PR TITLE
Add WhatsApp contact and shipping warning

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -66,6 +66,10 @@
                 <!-- Order summary will be injected here -->
             </div>
             <button id="pay-button" class="btn btn-success btn-lg mt-3">Bayar Sekarang</button>
+            <div class="alert alert-warning mt-3" id="shipping-warning">
+                Pengiriman ke luar Jabodetabek memerlukan konfirmasi terlebih dahulu melalui WhatsApp
+                <a href="https://wa.me/6285770526408" target="_blank" rel="noopener noreferrer">+62 857-7052-6408</a>.
+            </div>
         </section>
     </main>
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,14 @@
                 </div>
             </div>
         </section>
+
+        <section id="contact-info" class="py-5 bg-light">
+            <div class="container text-center">
+                <h2>Kontak Kami</h2>
+                <p>Untuk informasi lebih lanjut silakan hubungi kami melalui WhatsApp.</p>
+                <a href="https://wa.me/6285770526408" class="btn btn-success" target="_blank" rel="noopener noreferrer">Chat WhatsApp</a>
+            </div>
+        </section>
     </main>
 
     <footer class="py-4 bg-dark text-white text-center">


### PR DESCRIPTION
## Summary
- add a contact section with WhatsApp link on the index page
- show a warning on the cart page to confirm shipping outside Jabodetabek via WhatsApp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871473dba58832282862172d2a76a53